### PR TITLE
Docker: Add docker support for building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ yarn-debug.log*
 yarn-error.log*
 
 src/conf/config.json
+out/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:13-buster
+
+WORKDIR /app
+
+RUN mkdir /app/out/
+
+COPY package.json ./
+
+RUN apt-get update
+RUN npm install
+
+COPY . .
+ENTRYPOINT ["bash", "scripts/build-webrcade-app-common.sh"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ This repository contains common components that are available for use by the web
  <i>webЯcade on Chrome for macOS</i>
 </p>
 
+## BUILDING
+You can build the webЯcade Common Library through docker. Please ensure you have docker installed locally.
+
+```
+bash docker-run.sh
+```
+
+This will result in a .tgz file being created in a newly created out/ folder locally.
+
 ## LICENSE
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,2 @@
+bash scripts/build-docker-image.sh
+docker run -v "$(pwd)"/out:/app/out webrcade-app-common

--- a/scripts/build-docker-image.sh
+++ b/scripts/build-docker-image.sh
@@ -1,0 +1,1 @@
+docker build -t webrcade-app-common .

--- a/scripts/build-webrcade-app-common.sh
+++ b/scripts/build-webrcade-app-common.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+npm run-script build
+npm pack
+cp *.tgz out/


### PR DESCRIPTION
This PR adds support for building webrcade-app-common in a docker container.

There are 3 scripts that handle the bulk of the work here:

`docker-run.sh`: This is the user interactable script. It will build the docker image, and run it. The output of this will be a webrcade-app-common.tgz in a local "out/" folder

`scripts/build-docker-image.sh`: Build the docker image locally

`scripts/build-webracde-app-common.sh`: This script gets built in to the docker image and handles actually building webrcade-app-common

Here is an example:

```
webrcade-app-common$ bash docker-run.sh 
Sending build context to Docker daemon   1.88MB
Step 1/8 : FROM node:13-buster
 ---> 510c68520fc4
Step 2/8 : WORKDIR /app
 ---> Using cache
 ---> 8f5bd5fdf471
Step 3/8 : RUN mkdir /app/out/
 ---> Using cache
 ---> 4458dcc5ad74
Step 4/8 : COPY package.json ./
 ---> Using cache
 ---> 33a24df8b7a6
Step 5/8 : RUN apt-get update
 ---> Using cache
 ---> a79f756c1cb6
Step 6/8 : RUN npm install
 ---> Using cache
 ---> 0c4d98c91dd7
Step 7/8 : COPY . .
 ---> 7598c3a3bfa5
Step 8/8 : ENTRYPOINT ["bash", "scripts/build-webrcade-app-common.sh"]
 ---> Running in 113b739aa7ee
Removing intermediate container 113b739aa7ee
 ---> 2d8bc2ff0a84
Successfully built 2d8bc2ff0a84
Successfully tagged webrcade-app-common:latest

> @webrcade/app-common@0.1.0 build /app
> microbundle-crl --no-compress --format modern,cjs

Build "appCommon" to dist:
      44.7 kB: index.js.gz
      37.3 kB: index.js.br
      44.3 kB: index.modern.js.gz
      37.1 kB: index.modern.js.br
npm WARN lifecycle @webrcade/app-common@0.1.0~prepare: cannot run in wd @webrcade/app-common@0.1.0 run-s build (wd=/app)
npm notice 
npm notice package: @webrcade/app-common@0.1.0
npm notice === Tarball Contents === 
npm notice 11.4kB  LICENSE                 
npm notice 9.5kB   dist/index.css          
npm notice 221.6kB dist/index.js           
npm notice 218.8kB dist/index.modern.js    
npm notice 1.6kB   package.json            
npm notice 520.4kB dist/index.js.map       
npm notice 520.1kB dist/index.modern.js.map
npm notice 1.2kB   README.md               
npm notice === Tarball Details === 
npm notice name:          @webrcade/app-common                    
npm notice version:       0.1.0                                   
npm notice filename:      webrcade-app-common-0.1.0.tgz           
npm notice package size:  355.5 kB                                
npm notice unpacked size: 1.5 MB                                  
npm notice shasum:        6df99e34dbae60f9b3b1f4c3eab85ec38c9831fe
npm notice integrity:     sha512-zPqZgeM2PpEmR[...]UiTvsPa/b3FmQ==
npm notice total files:   8                                       
npm notice 
webrcade-app-common-0.1.0.tgz

webrcade-app-common$ ls out/
webrcade-app-common-0.1.0.tgz
```
