### PR TITLE
Add box.com URL remapping.

### DIFF
--- a/src/app/remapurl.js
+++ b/src/app/remapurl.js
@@ -5,6 +5,7 @@ const DB_PREFIX = "https://www.dropbox.com/";
 const DB_REMAP_PREFIX = "https://dl.dropboxusercontent.com/";
 const GDRIVE_PREFIX ="https://drive.google.com/file/d/";
 const GDRIVE_REMAP_PREFIX = "https://drive.google.com/uc?export=download&id=";
+const BOX_PREFIX = "https://app.box.com/file/"; 
 
 const IMG_PREFIX = "https://play.webrcade.com/default-feed/images/";
 const IMG_REMAP_PREFIX = "https://webrcade.github.io/webrcade-default-feed/images/";
@@ -44,6 +45,24 @@ const remapGdrive = (urlLower, url) => {
   }
   return null;
 }
+
+const remapBox = (urlLower, url) => {
+  // Check for Box.com shared file prefix
+  if (urlLower.substring(0, BOX_PREFIX.length) === BOX_PREFIX) {
+    const fileId = url.substring(BOX_PREFIX.length).split('?')[0];
+    const sharedNameMatch = url.match(/[?&]s=([^&]+)/);
+    if (!sharedNameMatch) {
+      return null; // Return null if the 's' parameter (SHARED-NAME) is missing
+    }
+    const sharedName = sharedNameMatch[1];
+    url = `https://app.box.com/index.php?rm=box_download_shared_file&shared_name=${sharedName}&file_id=f_${fileId}`;
+    if (isDebug()) {
+      LOG.info("Remapped Box.com url: '" + url + "'");
+    }
+    return url;
+  }
+  return null;
+};
 
 const remapOldDefaultImage = (urlLower, url) => {
   if (urlLower.substring(0, IMG_PREFIX.length) === IMG_PREFIX) {


### PR DESCRIPTION
I'll admit, I used AI to help me write this, but I gave it a once-over to try to match code styles and correct assumptions that the AI made.

This code should make it possible to automatically create Box.com direct links from shared links without needing a separate tool or linksmithing by hand. The links we are looking for will be in the format `https://app.box.com/file/FILE-ID?s=SHARED-NAME` and the target format is `https://app.box.com/index.php?rm=box_download_shared_file&shared_name=SHARED-NAME&file_id=f_FILE-ID` Since two values need to be found and rearranged, this code is designed to handle the possibility of the `s=` parameter being missing by returning null as a fail safe, even though it's almost certain that this will never happen in practice.

For testing, I uploaded a copy of Box's logo to my box drive. It is at `https://app.box.com/file/1763630307794?s=q9r5bqqn60j9g1xu8nqp2rmxlk1pbvcq`

An inherent limitation with Box's shared file implementation is that the share link Box gives you must be pasted into a browser in order for both needed values to be resolved. For instance, Box tells me that the link to the logo I uploaded is `https://app.box.com/s/q9r5bqqn60j9g1xu8nqp2rmxlk1pbvcq`. When opened in a browser, you are redirected to a landing page from where the full url can be copied from the address bar.